### PR TITLE
Update AuthenticateHubMiddleware.php

### DIFF
--- a/src/Middleware/AuthenticateHubMiddleware.php
+++ b/src/Middleware/AuthenticateHubMiddleware.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use stdClass;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class AuthAttemptMiddleware.


### PR DESCRIPTION
fix:
Argument 1 passed to BildVitta\Hub\Middleware\AuthenticateHubMiddleware::BildVitta\Hub\Middleware\{closure}() must be an instance of BildVitta\Hub\Middleware\Builder, instance of Illuminate\Database\Eloquent\Builder given, called in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php on line 259