### PR TITLE
Use array to store find permissions.

### DIFF
--- a/src/Traits/LoginUser.php
+++ b/src/Traits/LoginUser.php
@@ -91,12 +91,11 @@ trait LoginUser
         foreach ($permissions as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $array) {
-                    $findPermission = Permission::findOrCreate("$key.$array", 'web');
+                    $userPermissions[] = Permission::findOrCreate("$key.$array", 'web');
                 }
             } else {
-                $findPermission = Permission::findOrCreate("$key.$value", 'web');
+                $userPermissions[] = Permission::findOrCreate("$key.$value", 'web');
             }
-            $userPermissions[] = $findPermission;
         }
 
         if (!empty($permissions)) {


### PR DESCRIPTION
**Problema**
Permissões que vinham como `array` não eram liberadas de forma correta, fazendo que somente a ultima permissão fosse liberada.

**Solução**
Quando um item das `$permissions` for um `array` guardar o retorno do `Permission::findOrCreate` diretamente em um `array`
