### PR TITLE
Clear Spatie permission cache when local permissions are different fr…

### DIFF
--- a/src/Traits/LoginUser.php
+++ b/src/Traits/LoginUser.php
@@ -90,6 +90,11 @@ trait LoginUser
     protected function updateUserPermissions($user, stdClass $apiUser)
     {
         $permissions = $apiUser->user_permissions;
+
+        if ($user->getAllPermissions()->count() !== collect($permissions)->flatten()->count()) {
+            $this->clearPermissionsCache();
+        }
+
         $userPermissions = [];
         foreach ($permissions as $key => $value) {
             if (is_array($value)) {
@@ -104,6 +109,12 @@ trait LoginUser
         $user->syncPermissions(... collect($userPermissions)->pluck('name')->toArray());
 
         return false;
+    }
+
+    private function clearPermissionsCache()
+    {
+        $permissionCacheKey = config('permission.cache.key');
+        Cache::forget($permissionCacheKey);
     }
 
     protected function getUserCompany($user, stdClass $apiUser)


### PR DESCRIPTION
**Problema**
Várias vezes temos problema ao fazer sync das permissões e recebemos o erro 
```
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`assistencia-digital`.`model_has_permissions`, CONSTRAINT `model_has_permissions_permission_id_foreign` FOREIGN KEY (`permission_id`)
REFERENCES `permissions` (`id`) ON DELETE CASCADE) (SQL: insert into `model_has_permissions` (`model_id`, `model_type`, `permission_id`) values (4, App\Models\User, 561))
```

**Solução**
Comparar a quantidade de permissões locais com as que estão sendo enviadas para sync, caso forem diferentes limpa o `Cache` do Spatie.

