### PR TITLE
Fix state cache key

### DIFF
--- a/src/Http/Controllers/Auth/CallbackController.php
+++ b/src/Http/Controllers/Auth/CallbackController.php
@@ -6,6 +6,7 @@ namespace BildVitta\Hub\Http\Controllers\Auth;
 use BildVitta\Hub\Entities\HubOauthToken;
 use BildVitta\Hub\Http\Requests\CallbackRequest;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -16,10 +17,14 @@ class CallbackController extends AuthController
 {
     public function __invoke(CallbackRequest $request)
     {
-        $state = cache()->pull('state', '');
-        $url = cache()->pull($state);
+        $stateExploded = Str::of($request->state)->explode('.');
+        $stateFromParam = $stateExploded->first();
+        $stateComplement = $stateExploded->last();
 
-        if (!(strlen($state) > 0 && $state === $request->state)) {
+        $stateFromCache = cache()->pull("state.{$stateComplement}", '');
+        $url = cache()->pull($stateFromCache);
+
+        if (!(strlen($stateFromCache) > 0 && $stateFromCache === $stateFromParam)) {
             throw new NotFoundHttpException(__('State is not valid'));
         }
 

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -15,8 +15,9 @@ class LoginController extends AuthController
     public function __invoke(LoginRequest $request)
     {
         $state = Str::random(40);
+        $stateComplement = Str::random(12);
 
-        cache()->put('state', $state, now()->addMinutes(5));
+        cache()->put("state.{$stateComplement}", $state, now()->addMinutes(5));
         cache()->put($state, $request->get('url'), now()->addMinutes(5));
 
         $query = http_build_query([
@@ -24,7 +25,7 @@ class LoginController extends AuthController
             'redirect_uri' => config('hub.oauth.redirect'),
             'response_type' => 'code',
             'scope' => config('hub.oauth.scopes'),
-            'state' => $state,
+            'state' => "{$state}.{$stateComplement}",
             'url' => $request->get('url', '/')
         ]);
 


### PR DESCRIPTION
**Problema**
Ao fazer login o pacote gera uma chave com o nome `state` no cache que expira em cinco minutos.
Caso outro login aconteça dentro deste tempo de cinco minutos, o pacote sobrescreve a chave anterior fazendo que o login tenha um comportamento inesperado.
Ex: `State is not valid`

**Solução**
Gerar uma chave **única** complementando a chave `state`. Dessa forma a chave `state` não é sobrescrita fazendo com que o login aconteça de forma normal.

Devs:
@leandrohago e @paulo-bildvitta 